### PR TITLE
ref(gocd): use console script entry points

### DIFF
--- a/gocd/generated-pipelines/deploy-snuba-customer-1.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-customer-1.yaml
@@ -34,17 +34,17 @@ pipelines:
                 - script: |
                     ##!/bin/bash
 
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
                     /devinfra/scripts/k8s/k8stunnel
 
-                    /devinfra/scripts/k8s/k8s-deploy.py \
+                    k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --container-name="snuba" \
                       --container-name="snuba-admin"
 
-                    /devinfra/scripts/k8s/k8s-deploy.py \
+                    k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \

--- a/gocd/generated-pipelines/deploy-snuba-customer-1.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-customer-1.yaml
@@ -36,7 +36,7 @@ pipelines:
 
                     eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-                    /devinfra/scripts/k8s/k8stunnel
+                    /devinfra/scripts/get-cluster-credentials
 
                     k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \

--- a/gocd/generated-pipelines/deploy-snuba-customer-2.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-customer-2.yaml
@@ -34,17 +34,17 @@ pipelines:
                 - script: |
                     ##!/bin/bash
 
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
                     /devinfra/scripts/k8s/k8stunnel
 
-                    /devinfra/scripts/k8s/k8s-deploy.py \
+                    k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --container-name="snuba" \
                       --container-name="snuba-admin"
 
-                    /devinfra/scripts/k8s/k8s-deploy.py \
+                    k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \

--- a/gocd/generated-pipelines/deploy-snuba-customer-2.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-customer-2.yaml
@@ -36,7 +36,7 @@ pipelines:
 
                     eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-                    /devinfra/scripts/k8s/k8stunnel
+                    /devinfra/scripts/get-cluster-credentials
 
                     k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \

--- a/gocd/generated-pipelines/deploy-snuba-customer-4.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-customer-4.yaml
@@ -34,17 +34,17 @@ pipelines:
                 - script: |
                     ##!/bin/bash
 
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
                     /devinfra/scripts/k8s/k8stunnel
 
-                    /devinfra/scripts/k8s/k8s-deploy.py \
+                    k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --container-name="snuba" \
                       --container-name="snuba-admin"
 
-                    /devinfra/scripts/k8s/k8s-deploy.py \
+                    k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \

--- a/gocd/generated-pipelines/deploy-snuba-customer-4.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-customer-4.yaml
@@ -36,7 +36,7 @@ pipelines:
 
                     eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-                    /devinfra/scripts/k8s/k8stunnel
+                    /devinfra/scripts/get-cluster-credentials
 
                     k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \

--- a/gocd/generated-pipelines/deploy-snuba-customer-7.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-customer-7.yaml
@@ -34,17 +34,17 @@ pipelines:
                 - script: |
                     ##!/bin/bash
 
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
                     /devinfra/scripts/k8s/k8stunnel
 
-                    /devinfra/scripts/k8s/k8s-deploy.py \
+                    k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --container-name="snuba" \
                       --container-name="snuba-admin"
 
-                    /devinfra/scripts/k8s/k8s-deploy.py \
+                    k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \

--- a/gocd/generated-pipelines/deploy-snuba-customer-7.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-customer-7.yaml
@@ -36,7 +36,7 @@ pipelines:
 
                     eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-                    /devinfra/scripts/k8s/k8stunnel
+                    /devinfra/scripts/get-cluster-credentials
 
                     k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \

--- a/gocd/generated-pipelines/deploy-snuba-de.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-de.yaml
@@ -34,10 +34,10 @@ pipelines:
                 - script: |
                     ##!/bin/bash
 
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
                     /devinfra/scripts/k8s/k8stunnel \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --container-name="api" \
@@ -87,14 +87,14 @@ pipelines:
                       --container-name="eap-spans-consumer" \
                       --container-name="eap-mutations-consumer" \
                       --container-name="eap-spans-profiled-consumer" \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \
                       --container-name="cleanup" \
                       --container-name="optimize" \
                       --container-name="cardinality-report" \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="statefulset" \

--- a/gocd/generated-pipelines/deploy-snuba-de.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-de.yaml
@@ -36,7 +36,7 @@ pipelines:
 
                     eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-                    /devinfra/scripts/k8s/k8stunnel \
+                    /devinfra/scripts/get-cluster-credentials \
                     && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \

--- a/gocd/generated-pipelines/deploy-snuba-s4s.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-s4s.yaml
@@ -33,7 +33,7 @@ pipelines:
 
                     eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-                    /devinfra/scripts/k8s/k8stunnel
+                    /devinfra/scripts/get-cluster-credentials
 
                     k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \

--- a/gocd/generated-pipelines/deploy-snuba-s4s.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-s4s.yaml
@@ -31,17 +31,17 @@ pipelines:
                 - script: |
                     ##!/bin/bash
 
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
                     /devinfra/scripts/k8s/k8stunnel
 
-                    /devinfra/scripts/k8s/k8s-deploy.py \
+                    k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --container-name="snuba" \
                       --container-name="snuba-admin"
 
-                    /devinfra/scripts/k8s/k8s-deploy.py \
+                    k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \

--- a/gocd/generated-pipelines/deploy-snuba-us.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-us.yaml
@@ -36,7 +36,7 @@ pipelines:
 
                     eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-                    /devinfra/scripts/k8s/k8stunnel \
+                    /devinfra/scripts/get-cluster-credentials \
                     && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \

--- a/gocd/generated-pipelines/deploy-snuba-us.yaml
+++ b/gocd/generated-pipelines/deploy-snuba-us.yaml
@@ -34,10 +34,10 @@ pipelines:
                 - script: |
                     ##!/bin/bash
 
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
                     /devinfra/scripts/k8s/k8stunnel \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --container-name="api" \
@@ -87,14 +87,14 @@ pipelines:
                       --container-name="eap-spans-consumer" \
                       --container-name="eap-mutations-consumer" \
                       --container-name="eap-spans-profiled-consumer" \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \
                       --container-name="cleanup" \
                       --container-name="optimize" \
                       --container-name="cardinality-report" \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="statefulset" \
@@ -102,7 +102,7 @@ pipelines:
                 - script: |
                     ##!/bin/bash
 
-                    /devinfra/scripts/checks/datadog/monitor_status.py \
+                    checks-datadog-monitor-status \
                       140973101
 
 
@@ -119,10 +119,10 @@ pipelines:
                 - script: |
                     ##!/bin/bash
 
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
                     /devinfra/scripts/k8s/k8stunnel \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --container-name="api" \
@@ -172,14 +172,14 @@ pipelines:
                       --container-name="eap-spans-consumer" \
                       --container-name="eap-mutations-consumer" \
                       --container-name="eap-spans-profiled-consumer" \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \
                       --container-name="cleanup" \
                       --container-name="optimize" \
                       --container-name="cardinality-report" \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    && k8s-deploy \
                       --label-selector="${LABEL_SELECTOR}" \
                       --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
                       --type="statefulset" \

--- a/gocd/pipelines/test-pipeline.yaml
+++ b/gocd/pipelines/test-pipeline.yaml
@@ -33,7 +33,7 @@ pipelines:
             - exec:
                 command: ./scripts/sayhi.sh
             - script: |
-                gcloud-gcloud-wait
+                gcloud-wait
                 gcloud container clusters get-credentials "$GKE_CLUSTER" --region "$GKE_REGION" --project "$GCP_PROJECT"
             - script: |
                 kubectl get pods -n gocd

--- a/gocd/pipelines/test-pipeline.yaml
+++ b/gocd/pipelines/test-pipeline.yaml
@@ -33,11 +33,11 @@ pipelines:
             - exec:
                 command: ./scripts/sayhi.sh
             - script: |
-                /devinfra/scripts/gcloud/gcloud-wait.py
+                gcloud-gcloud-wait
                 gcloud container clusters get-credentials "$GKE_CLUSTER" --region "$GKE_REGION" --project "$GCP_PROJECT"
             - script: |
                 kubectl get pods -n gocd
                 kubectl get pods -n default
             - exec:
-                command: /devinfra/scripts/k8s/k8s-deploy.py
+                command: k8s-deploy
 

--- a/gocd/templates/bash/canary-ddog-health-check.sh
+++ b/gocd/templates/bash/canary-ddog-health-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/datadog/monitor_status.py \
+checks-datadog-monitor-status \
   140973101
 
 

--- a/gocd/templates/bash/check-cloud-build.sh
+++ b/gocd/templates/bash/check-cloud-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
+checks-googlecloud-check-cloudbuild \
   ${GO_REVISION_SNUBA_REPO} \
   sentryio \
   "us-central1-docker.pkg.dev/sentryio/snuba/image"

--- a/gocd/templates/bash/deploy-st.sh
+++ b/gocd/templates/bash/deploy-st.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-deploy.py \
+k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   --container-name="snuba" \
   --container-name="snuba-admin"
 
-/devinfra/scripts/k8s/k8s-deploy.py \
+k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   --type="cronjob" \

--- a/gocd/templates/bash/deploy-st.sh
+++ b/gocd/templates/bash/deploy-st.sh
@@ -2,7 +2,7 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-/devinfra/scripts/k8s/k8stunnel
+/devinfra/scripts/get-cluster-credentials
 
 k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel \
-&& /devinfra/scripts/k8s/k8s-deploy.py \
+&& k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   --container-name="api" \
@@ -53,14 +53,14 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="eap-spans-consumer" \
   --container-name="eap-mutations-consumer" \
   --container-name="eap-spans-profiled-consumer" \
-&& /devinfra/scripts/k8s/k8s-deploy.py \
+&& k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   --type="cronjob" \
   --container-name="cleanup" \
   --container-name="optimize" \
   --container-name="cardinality-report" \
-&& /devinfra/scripts/k8s/k8s-deploy.py \
+&& k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   --type="statefulset" \

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -2,7 +2,7 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-/devinfra/scripts/k8s/k8stunnel \
+/devinfra/scripts/get-cluster-credentials \
 && k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \

--- a/gocd/templates/bash/migrate-reverse.sh
+++ b/gocd/templates/bash/migrate-reverse.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-spawn-job.py \
+k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
   "snuba-migrate-reverse" \

--- a/gocd/templates/bash/migrate-reverse.sh
+++ b/gocd/templates/bash/migrate-reverse.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
-/devinfra/scripts/k8s/k8stunnel
+/devinfra/scripts/get-cluster-credentials
 
 k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \

--- a/gocd/templates/bash/migrate-st.sh
+++ b/gocd/templates/bash/migrate-st.sh
@@ -7,7 +7,7 @@
 # out a common migration script for all regions.
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
-/devinfra/scripts/k8s/k8stunnel
+/devinfra/scripts/get-cluster-credentials
 
 k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \

--- a/gocd/templates/bash/migrate-st.sh
+++ b/gocd/templates/bash/migrate-st.sh
@@ -6,10 +6,10 @@
 # This script should be merged with migrate.sh if we can figure
 # out a common migration script for all regions.
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-spawn-job.py \
+k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
   "snuba-migrate" \

--- a/gocd/templates/bash/migrate.sh
+++ b/gocd/templates/bash/migrate.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-spawn-job.py \
+k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
   "snuba-migrate" \

--- a/gocd/templates/bash/migrate.sh
+++ b/gocd/templates/bash/migrate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
-/devinfra/scripts/k8s/k8stunnel
+/devinfra/scripts/get-cluster-credentials
 
 k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \

--- a/gocd/templates/bash/s4s-clickhouse-queries.sh
+++ b/gocd/templates/bash/s4s-clickhouse-queries.sh
@@ -18,10 +18,10 @@ fi
 SNUBA_COMPONENT_NAME="query-${SNUBA_CMD_TYPE}-gocd"
 SNUBA_CMD="query-${SNUBA_CMD_TYPE} ${ARGS[@]}"
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-spawn-job.py \
+k8s-spawn-job \
   --label-selector="service=snuba,component=${SNUBA_COMPONENT_NAME}" \
   --container-name="${SNUBA_COMPONENT_NAME}" \
   --try-deployments-and-statefulsets \

--- a/gocd/templates/bash/s4s-clickhouse-queries.sh
+++ b/gocd/templates/bash/s4s-clickhouse-queries.sh
@@ -19,7 +19,7 @@ SNUBA_COMPONENT_NAME="query-${SNUBA_CMD_TYPE}-gocd"
 SNUBA_CMD="query-${SNUBA_CMD_TYPE} ${ARGS[@]}"
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
-/devinfra/scripts/k8s/k8stunnel
+/devinfra/scripts/get-cluster-credentials
 
 k8s-spawn-job \
   --label-selector="service=snuba,component=${SNUBA_COMPONENT_NAME}" \


### PR DESCRIPTION
Updating gocd scripts to use console script entry points.

Please see: https://github.com/getsentry/devinfra-deployment-service/pull/698